### PR TITLE
Initial Travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,5 @@
 .obj
 libmpsocket.o
 libmpsocket.so
-test/http-*
-test/mhttp-*
 *.swp
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.libs
+.deps
+.obj
+libmpsocket.o
+libmpsocket.so
+test/http-*
+test/mhttp-*
+*.swp
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 script:
     - make clean
     - make
-    - sudo ./run.sh 64 3 wlp2s0,wlp2s0 0 http://mirror.its.dal.ca/archlinux/iso/2016.10.01/archlinux-bootstrap-2016.10.01-i686.tar.gz 15 30 40
+    - sudo make test-1M
+    - sudo make test-5M
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ RM=rm -rf
 
 OPT=-O2 -lpthread
 
-TEST_IF=wlp2s0,wlp2s0
-
 # INFO LOG LEVEL
 #LIB_LOG_LVL=4
 #OBJ_LOG_LVL=4
@@ -83,13 +81,15 @@ sanity: $(LIB).so
 	@$(RM) 943451_423790771050103_1325449100_n.jpg*
 
 test-1M:
-	wget -O ./test/http-1M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/1M
-	sudo LD_PRELOAD=./libmpsocket.so INITIAL_CHUNK_SIZE_IN_KB=64 CONNECTIONS=2 INTERFACES=$(T_IFS) IPADDRS=0 wget -e robots=off -E -H -K -v -t 1 --no-check-certificate --no-cache --no-proxy --no-dns-cache -p -O ./test/mhttp-1M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/1M
+	mkdir -p ./test
+	wget -O ./test/http-1M-result http://fishi.devtail.com/content-images/mhttp-blobs/1M
+	sudo LD_PRELOAD=./libmpsocket.so INITIAL_CHUNK_SIZE_IN_KB=64 CONNECTIONS=2 INTERFACES=eth0,eth0 IPADDRS=0 wget -e robots=off -E -H -K -v -t 1 --no-check-certificate --no-cache --no-proxy --no-dns-cache -O ./test/mhttp-1M-result http://fishi.devtail.com/content-images/mhttp-blobs/1M
 	diff ./test/mhttp-1M-result ./test/http-1M-result && (echo "Success" && exit 0) || (exit 1)
 
 test-5M:
-	wget -O ./test/http-5M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/5M
-	sudo LD_PRELOAD=./libmpsocket.so INITIAL_CHUNK_SIZE_IN_KB=64 CONNECTIONS=2 INTERFACES=$(T_IFS) IPADDRS=0 wget -e robots=off -E -H -K -v -t 1 --no-check-certificate --no-cache --no-proxy --no-dns-cache -p -O ./test/mhttp-5M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/5M
+	mkdir -p ./test
+	wget -O ./test/http-5M-result http://fishi.devtail.com/content-images/mhttp-blobs/5M
+	sudo LD_PRELOAD=./libmpsocket.so INITIAL_CHUNK_SIZE_IN_KB=64 CONNECTIONS=2 INTERFACES=eth0,eth0 IPADDRS=0 wget -e robots=off -E -H -K -v -t 1 --no-check-certificate --no-cache --no-proxy --no-dns-cache -O ./test/mhttp-5M-result http://fishi.devtail.com/content-images/mhttp-blobs/5M
 	diff ./test/mhttp-5M-result ./test/http-5M-result && (echo "Success" && exit 0) || (exit 1)
     
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ RM=rm -rf
 
 OPT=-O2 -lpthread
 
+TEST_IF=wlp2s0,wlp2s0
+
 # INFO LOG LEVEL
 #LIB_LOG_LVL=4
 #OBJ_LOG_LVL=4
@@ -79,6 +81,17 @@ sanity: $(LIB).so
 	@md5sum 943451_423790771050103_1325449100_n.jpg.1
 	@echo " ";
 	@$(RM) 943451_423790771050103_1325449100_n.jpg*
+
+test-1M:
+	wget -O ./test/http-1M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/1M
+	sudo LD_PRELOAD=./libmpsocket.so INITIAL_CHUNK_SIZE_IN_KB=64 CONNECTIONS=2 INTERFACES=$(T_IFS) IPADDRS=0 wget -e robots=off -E -H -K -v -t 1 --no-check-certificate --no-cache --no-proxy --no-dns-cache -p -O ./test/mhttp-1M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/1M
+	diff ./test/mhttp-1M-result ./test/http-1M-result && (echo "Success" && exit 0) || (exit 1)
+
+test-5M:
+	wget -O ./test/http-5M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/5M
+	sudo LD_PRELOAD=./libmpsocket.so INITIAL_CHUNK_SIZE_IN_KB=64 CONNECTIONS=2 INTERFACES=$(T_IFS) IPADDRS=0 wget -e robots=off -E -H -K -v -t 1 --no-check-certificate --no-cache --no-proxy --no-dns-cache -p -O ./test/mhttp-5M-result http://github.com/darcy95/mhttp/raw/travis/test/blobs/5M
+	diff ./test/mhttp-5M-result ./test/http-5M-result && (echo "Success" && exit 0) || (exit 1)
+    
 
 clean:
 	$(RM) $(LIB).o

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### Status
+[![Master branch build status](https://travis-ci.org/darcy95/mhttp.svg?branch=master)](https://travis-ci.org/darcy95/mhttp.svg?branch=master)
+
 # mHTTP
 In today’s Internet, one of the main detriments in user experience is completion times of data transfers that for large objects is limited by network capacity. However, recent developments have opened new opportunities for reducing end-to-end latencies. First, most end-user devices have multiple network interfaces (i. e., interface diversity). Second, popular contents are often available at multiple locations in the network (i. e., data source diversity). When combined, these provide substantial path diversity within the Internet that can be used by users to improve their quality of experience.
 


### PR DESCRIPTION
References Issue #1 

Adds a 1M and 5M blob test download run. Each test follows the following procedure:
1. The file is downloaded via normal HTTP. 
2. The file is downloaded via mHTTP. 
3. We confirm that the files are equal. 

For now, the test blobs are uploaded to github pages, since those are reachable via http (whereas github raw content download enforces ssl, which is not supported yet by mHTTP...). 

Currently, the throughput is very high inside the Travis VM. Later, I will try to add some bandwidth limits and noise to the VM's interface (e.g., via `tc`), so we have a more realistic download scenario. 
